### PR TITLE
Discard master/slave vocabulary

### DIFF
--- a/google-cloud-sdk/platform/gsutil/gslib/addlhelp/naming.py
+++ b/google-cloud-sdk/platform/gsutil/gslib/addlhelp/naming.py
@@ -94,8 +94,8 @@ _DETAILED_HELP_TEXT = ("""
   user who creates the bucket, so the user who creates the bucket must
   also be verified as an owner or manager of the domain.
 
-  To verify as the owner or manager of a domain, use the Google Webmaster
-  Tools verification process. The Webmaster Tools verification process
+  To verify as the owner or manager of a domain, use the Google Webmain
+  Tools verification process. The Webmain Tools verification process
   provides three methods for verifying an owner or manager of a domain:
 
   1. Adding a special Meta tag to a site's homepage.

--- a/google-cloud-sdk/platform/gsutil/gslib/commands/notification.py
+++ b/google-cloud-sdk/platform/gsutil/gslib/commands/notification.py
@@ -316,7 +316,7 @@ which is not authorized for your project. Please ensure that you are using
 Service Account authentication and that the Service Account's project is
 authorized for the application URL. Notification endpoint URLs must also be
 whitelisted in your Cloud Console project. To do that, the domain must also be
-verified using Google Webmaster Tools. For instructions, please see:
+verified using Google Webmain Tools. For instructions, please see:
 
   https://cloud.google.com/storage/docs/object-change-notification#_Authorization
 """

--- a/google-cloud-sdk/platform/gsutil/gslib/ui_controller.py
+++ b/google-cloud-sdk/platform/gsutil/gslib/ui_controller.py
@@ -1044,7 +1044,7 @@ class UIController(object):
 
 
 class MainThreadUIQueue(object):
-  """Handles status display and processing in the main thread / master process.
+  """Handles status display and processing in the main thread / main process.
 
   This class emulates a queue to cover main-thread activity before or after
   Apply, as well as for the single-threaded, single-process case, i.e.,

--- a/google-cloud-sdk/platform/gsutil/third_party/apitools/apitools/base/py/batch.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/apitools/apitools/base/py/batch.py
@@ -174,7 +174,7 @@ class BatchApiRequest(object):
             method_config, request, global_params=global_params,
             upload_config=upload_config)
 
-        # Create the request and add it to our master list.
+        # Create the request and add it to our main list.
         api_request = self.ApiCall(
             http_request, self.retryable_codes, service, method_config)
         self.api_requests.append(api_request)

--- a/google-cloud-sdk/platform/gsutil/third_party/apitools/run_pylint.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/apitools/run_pylint.py
@@ -111,9 +111,9 @@ def get_files_for_linting(allow_limited=True, diff_base=None):
     uses a specific commit or branch (a so-called diff base) to compare
     against for changed files. (This requires ``allow_limited=True``.)
 
-    To speed up linting on Travis pull requests against master, we manually
-    set the diff base to origin/master. We don't do this on non-pull requests
-    since origin/master will be equivalent to the currently checked out code.
+    To speed up linting on Travis pull requests against main, we manually
+    set the diff base to origin/main. We don't do this on non-pull requests
+    since origin/main will be equivalent to the currently checked out code.
     One could potentially use ${TRAVIS_COMMIT_RANGE} to find a diff base but
     this value is not dependable.
 
@@ -126,14 +126,14 @@ def get_files_for_linting(allow_limited=True, diff_base=None):
               linted.
     """
     if os.getenv('TRAVIS') == 'true':
-        # In travis, don't default to master.
+        # In travis, don't default to main.
         diff_base = None
 
-    if (os.getenv('TRAVIS_BRANCH') == 'master' and
+    if (os.getenv('TRAVIS_BRANCH') == 'main' and
             os.getenv('TRAVIS_PULL_REQUEST') != 'false'):
-        # In the case of a pull request into master, we want to
-        # diff against HEAD in master.
-        diff_base = 'origin/master'
+        # In the case of a pull request into main, we want to
+        # diff against HEAD in main.
+        diff_base = 'origin/main'
 
     if diff_base is not None and allow_limited:
         result = subprocess.check_output(['git', 'diff', '--name-only',

--- a/google-cloud-sdk/platform/gsutil/third_party/argcomplete/docs/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/argcomplete/docs/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'argcomplete'

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/connection.py
@@ -408,8 +408,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -436,11 +436,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -471,7 +471,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -526,15 +526,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -721,15 +721,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/step.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/kms/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/opsworks/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/pyami/bootstrap.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/__init__.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/__init__.py
@@ -138,8 +138,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -168,8 +168,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -222,8 +222,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -240,8 +240,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -398,8 +398,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -423,8 +423,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -562,7 +562,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -593,8 +593,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -680,8 +680,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbinstance.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbsnapshot.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds2/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds2/layer1.py
@@ -321,8 +321,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -417,9 +417,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -452,8 +452,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -536,7 +536,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -656,8 +656,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2488,7 +2488,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2616,14 +2616,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2634,7 +2634,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2668,7 +2668,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2820,8 +2820,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/redshift/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
@@ -44,8 +44,8 @@ class TestRDS2Connection(unittest.TestCase):
             allocated_storage=5,
             db_instance_class='db.t1.micro',
             engine='postgres',
-            master_username='bototestuser',
-            master_user_password='testtestt3st',
+            main_username='bototestuser',
+            main_user_password='testtestt3st',
             # Try to limit the impact & test options.
             multi_az=False,
             backup_retention_period=0

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
@@ -36,8 +36,8 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         self.api = RedshiftConnection()
         self.cluster_prefix = 'boto-redshift-cluster-%s'
         self.node_type = 'dw.hs1.xlarge'
-        self.master_username = 'mrtest'
-        self.master_password = 'P4ssword'
+        self.main_username = 'mrtest'
+        self.main_password = 'P4ssword'
         self.db_name = 'simon'
         # Redshift was taking ~20 minutes to bring clusters up in testing.
         self.wait_time = 60 * 20
@@ -50,7 +50,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 
@@ -71,7 +71,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_connection.py
@@ -193,7 +193,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
             <EndDateTime>2014-01-24T02:19:46Z</EndDateTime>
           </Timeline>
         </Status>
-        <Name>Master instance group</Name>
+        <Name>Main instance group</Name>
         <RequestedInstanceCount>1</RequestedInstanceCount>
         <RunningInstanceCount>0</RunningInstanceCount>
         <InstanceGroupType>MASTER</InstanceGroupType>
@@ -253,7 +253,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
         self.assertEqual(response.instancegroups[0].instancetype, "m1.large")
         self.assertEqual(response.instancegroups[0].market, "ON_DEMAND")
         self.assertEqual(
-            response.instancegroups[0].name, "Master instance group")
+            response.instancegroups[0].name, "Main instance group")
         self.assertEqual(
             response.instancegroups[0].requestedinstancecount, '1')
         self.assertEqual(response.instancegroups[0].runninginstancecount, '0')
@@ -587,7 +587,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         </member>
       </Applications>
       <TerminationProtected>false</TerminationProtected>
-      <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+      <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
       <NormalizedInstanceHours>10</NormalizedInstanceHours>
       <ServiceRole>my-service-role</ServiceRole>
     </Cluster>
@@ -622,7 +622,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         self.assertEqual(response.applications[0].name, 'hadoop')
         self.assertEqual(response.applications[0].version, '1.0.3')
         self.assertEqual(
-            response.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+            response.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(response.normalizedinstancehours, '10')
         self.assertEqual(response.servicerole, 'my-service-role')
 
@@ -862,7 +862,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
           <Placement>
             <AvailabilityZone>us-west-1c</AvailabilityZone>
           </Placement>
-          <MasterInstanceType>m1.large</MasterInstanceType>
+          <MainInstanceType>m1.large</MainInstanceType>
           <Ec2KeyName>my_key</Ec2KeyName>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
           <InstanceGroups>
@@ -879,7 +879,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Market>ON_DEMAND</Market>
               <InstanceGroupId>ig-aaaaaa</InstanceGroupId>
               <InstanceRole>MASTER</InstanceRole>
-              <Name>Master instance group</Name>
+              <Name>Main instance group</Name>
             </member>
             <member>
               <CreationDateTime>2014-01-24T01:21:21Z</CreationDateTime>
@@ -897,11 +897,11 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Name>Core instance group</Name>
             </member>
           </InstanceGroups>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-aaaaaa</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-aaaaaa</MainInstanceId>
           <HadoopVersion>1.0.3</HadoopVersion>
           <NormalizedInstanceHours>12</NormalizedInstanceHours>
-          <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+          <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
           <InstanceCount>3</InstanceCount>
           <TerminationProtected>false</TerminationProtected>
         </Instances>
@@ -930,15 +930,15 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(jf.name, 'test analytics')
         self.assertEqual(jf.jobflowid, 'j-aaaaaa')
         self.assertEqual(jf.ec2keyname, 'my_key')
-        self.assertEqual(jf.masterinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstancetype, 'm1.large')
         self.assertEqual(jf.availabilityzone, 'us-west-1c')
         self.assertEqual(jf.keepjobflowalivewhennosteps, 'true')
-        self.assertEqual(jf.slaveinstancetype, 'm1.large')
-        self.assertEqual(jf.masterinstanceid, 'i-aaaaaa')
+        self.assertEqual(jf.subordinateinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstanceid, 'i-aaaaaa')
         self.assertEqual(jf.hadoopversion, '1.0.3')
         self.assertEqual(jf.normalizedinstancehours, '12')
         self.assertEqual(
-            jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+            jf.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(jf.instancecount, '3')
         self.assertEqual(jf.terminationprotected, 'false')
 
@@ -961,7 +961,7 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(ig.market, 'ON_DEMAND')
         self.assertEqual(ig.instancegroupid, 'ig-aaaaaa')
         self.assertEqual(ig.instancerole, 'MASTER')
-        self.assertEqual(ig.name, 'Master instance group')
+        self.assertEqual(ig.name, 'Main instance group')
 
     def test_describe_jobflows_no_args(self):
         self.set_http_response(200)
@@ -1033,8 +1033,8 @@ class TestRunJobFlow(AWSMockServiceTestCase):
             'Name': 'EmrCluster'},
             ignore_params_values=['ActionOnFailure', 'Instances.InstanceCount',
                                   'Instances.KeepJobFlowAliveWhenNoSteps',
-                                  'Instances.MasterInstanceType',
-                                  'Instances.SlaveInstanceType'])
+                                  'Instances.MainInstanceType',
+                                  'Instances.SubordinateInstanceType'])
 
     def test_run_jobflow_enable_debugging(self):
         self.region = 'ap-northeast-2'

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
@@ -85,8 +85,8 @@ JOB_FLOW_EXAMPLE = b"""
           <Placement>
             <AvailabilityZone>us-east-1a</AvailabilityZone>
           </Placement>
-          <SlaveInstanceType>m1.small</SlaveInstanceType>
-          <MasterInstanceType>m1.small</MasterInstanceType>
+          <SubordinateInstanceType>m1.small</SubordinateInstanceType>
+          <MainInstanceType>m1.small</MainInstanceType>
           <Ec2KeyName>myec2keyname</Ec2KeyName>
           <InstanceCount>4</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
@@ -281,8 +281,8 @@ JOB_FLOW_COMPLETED = b"""
         </Steps>
         <JobFlowId>j-3H3Q13JPFLU22</JobFlowId>
         <Instances>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-64c21609</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-64c21609</MainInstanceId>
           <Placement>
             <AvailabilityZone>us-east-1b</AvailabilityZone>
           </Placement>
@@ -300,7 +300,7 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>MASTER</InstanceRole>
               <InstanceGroupId>ig-EVMHOZJ2SCO8</InstanceGroupId>
-              <Name>master</Name>
+              <Name>main</Name>
             </member>
             <member>
               <CreationDateTime>2010-10-21T01:00:25Z</CreationDateTime>
@@ -315,13 +315,13 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>CORE</InstanceRole>
               <InstanceGroupId>ig-YZHDYVITVHKB</InstanceGroupId>
-              <Name>slave</Name>
+              <Name>subordinate</Name>
             </member>
           </InstanceGroups>
           <NormalizedInstanceHours>40</NormalizedInstanceHours>
           <HadoopVersion>0.20</HadoopVersion>
-          <MasterInstanceType>m1.large</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MasterPublicDnsName>
+          <MainInstanceType>m1.large</MainInstanceType>
+          <MainPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MainPublicDnsName>
           <Ec2KeyName>myubersecurekey</Ec2KeyName>
           <InstanceCount>10</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>false</KeepJobFlowAliveWhenNoSteps>
@@ -361,8 +361,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='mybucket/subdir/',
                             name='MyJobFlowName',
                             availabilityzone='us-east-1a',
-                            slaveinstancetype='m1.small',
-                            masterinstancetype='m1.small',
+                            subordinateinstancetype='m1.small',
+                            maininstancetype='m1.small',
                             ec2keyname='myec2keyname',
                             keepjobflowalivewhennosteps='true')
 
@@ -379,8 +379,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='s3n://example.emrtest.scripts/jobflow_logs/',
                             name='RealJobFlowName',
                             availabilityzone='us-east-1b',
-                            slaveinstancetype='m1.large',
-                            masterinstancetype='m1.large',
+                            subordinateinstancetype='m1.large',
+                            maininstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
         self.assertEquals(6, len(jobflow.steps))

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
@@ -19,7 +19,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         with self.assertRaisesRegexp(ValueError, 'bidprice must be specified'):
             InstanceGroup(1, 'MASTER', 'm1.small',
-                          'SPOT', 'master')
+                          'SPOT', 'main')
 
     def test_bidprice_missing_ondemand(self):
         """
@@ -27,14 +27,14 @@ class TestInstanceGroupArgs(unittest.TestCase):
         ON_DEMAND.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'ON_DEMAND', 'master')
+                                       'ON_DEMAND', 'main')
 
     def test_bidprice_Decimal(self):
         """
         Test InstanceGroup init works with bidprice type = Decimal.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=Decimal(1.10))
+                                       'SPOT', 'main', bidprice=Decimal(1.10))
         self.assertEquals('1.10', instance_group.bidprice[:4])
 
     def test_bidprice_float(self):
@@ -42,7 +42,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = float.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=1.1)
+                                       'SPOT', 'main', bidprice=1.1)
         self.assertEquals('1.1', instance_group.bidprice)
 
     def test_bidprice_string(self):
@@ -50,7 +50,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = string.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice='1.1')
+                                       'SPOT', 'main', bidprice='1.1')
         self.assertEquals('1.1', instance_group.bidprice)
 
 if __name__ == "__main__":

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_connection.py
@@ -88,7 +88,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
                   <InstanceCreateTime>2012-10-03T22:01:51.047Z</InstanceCreateTime>
                   <AllocatedStorage>200</AllocatedStorage>
                   <DBInstanceClass>db.m1.large</DBInstanceClass>
-                  <MasterUsername>awsuser</MasterUsername>
+                  <MainUsername>awsuser</MainUsername>
                   <StatusInfos>
                     <DBInstanceStatusInfo>
                       <Message></Message>
@@ -150,7 +150,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
             db.endpoint,
             (u'mydbinstance2.c0hjqouvn9mf.us-west-2.rds.amazonaws.com', 3306))
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'awsuser')
+        self.assertEqual(db.main_username, 'awsuser')
         self.assertEqual(db.availability_zone, 'us-west-2b')
         self.assertEqual(db.backup_retention_period, 1)
         self.assertEqual(db.preferred_backup_window, '10:30-11:00')
@@ -198,7 +198,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <ReadReplicaDBInstanceIdentifiers/>
                     <Engine>mysql</Engine>
                     <PendingModifiedValues>
-                        <MasterUserPassword>****</MasterUserPassword>
+                        <MainUserPassword>****</MainUserPassword>
                     </PendingModifiedValues>
                     <BackupRetentionPeriod>0</BackupRetentionPeriod>
                     <MultiAZ>false</MultiAZ>
@@ -252,7 +252,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                         <AllocatedStorage>10</AllocatedStorage>
                         <DBInstanceClass>db.m1.large</DBInstanceClass>
-                        <MasterUsername>master</MasterUsername>
+                        <MainUsername>main</MainUsername>
                 </DBInstance>
             </CreateDBInstanceResult>
             <ResponseMetadata>
@@ -267,7 +267,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -283,8 +283,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306
         }, ignore_params_values=['Version'])
 
@@ -293,10 +293,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
 
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
@@ -312,7 +312,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group=param_group,
             db_subnet_group_name='dbSubnetgroup01')
@@ -326,8 +326,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
         }, ignore_params_values=['Version'])
 
@@ -336,10 +336,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
         self.assertEqual(db.parameter_group.description, None)
@@ -383,7 +383,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
               <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
               <AllocatedStorage>10</AllocatedStorage>
               <DBInstanceClass>db.m1.large</DBInstanceClass>
-              <MasterUsername>master</MasterUsername>
+              <MainUsername>main</MainUsername>
             </DBInstance>
           </RestoreDBInstanceToPointInTimeResult>
           <ResponseMetadata>
@@ -411,7 +411,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
 
         self.assertEqual(db.parameter_group.name,
@@ -445,7 +445,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -460,8 +460,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -481,7 +481,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -496,8 +496,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -674,9 +674,9 @@ class TestRDSLogFileDownload(AWSMockServiceTestCase):
 
 2014-01-27 09:35:15.44 spid74      I/O is frozen on database rdsadmin. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:15.44 spid73      I/O is frozen on database master. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
+2014-01-27 09:35:15.44 spid73      I/O is frozen on database main. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:25.57 spid73      I/O was resumed on database master. No user action is required.
+2014-01-27 09:35:25.57 spid73      I/O was resumed on database main. No user action is required.
 
 2014-01-27 09:35:25.57 spid74      I/O was resumed on database rdsadmin. No user action is required.
 

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
@@ -27,7 +27,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.50</EngineVersion>
                     <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                     <PercentProgress>100</PercentProgress>
@@ -47,7 +47,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.49</EngineVersion>
                     <DBSnapshotIdentifier>mysnapshot1</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>sa</MasterUsername>
+                    <MainUsername>sa</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -64,7 +64,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.47</EngineVersion>
                     <DBSnapshotIdentifier>rds:simcoprod01-2012-04-02-00-01</DBSnapshotIdentifier>
                     <SnapshotType>automated</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -118,7 +118,7 @@ class TestCreateDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CreateDBSnapshotResult>
             <ResponseMetadata>
@@ -160,7 +160,7 @@ class TestCopyDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mycopieddbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CopyDBSnapshotResult>
             <ResponseMetadata>
@@ -202,7 +202,7 @@ class TestDeleteDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.47</EngineVersion>
                 <DBSnapshotIdentifier>mysnapshot2</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </DeleteDBSnapshotResult>
             <ResponseMetadata>
@@ -257,7 +257,7 @@ class TestRestoreDBInstanceFromDBSnapshot(AWSMockServiceTestCase):
                 <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                 <AllocatedStorage>10</AllocatedStorage>
                 <DBInstanceClass>db.m1.large</DBInstanceClass>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBInstance>
             </RestoreDBInstanceFromDBSnapshotResult>
             <ResponseMetadata>

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/route53/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/route53/test_connection.py
@@ -509,7 +509,7 @@ class TestTruncatedGetAllRRSetsRoute53(AWSMockServiceTestCase):
       <TTL>1800</TTL>
       <ResourceRecords>
         <ResourceRecord>
-          <Value>ns-1929.awsdns-93.net. hostmaster.awsdns.net. 1 10800 3600 604800 1800</Value>
+          <Value>ns-1929.awsdns-93.net. hostmain.awsdns.net. 1 10800 3600 604800 1800</Value>
         </ResourceRecord>
       </ResourceRecords>
     </ResourceRecordSet>

--- a/google-cloud-sdk/platform/gsutil/third_party/crcmod/docs/source/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/crcmod/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'crcmod'

--- a/google-cloud-sdk/platform/gsutil/third_party/funcsigs/docs/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/funcsigs/docs/conf.py
@@ -37,8 +37,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'funcsigs'

--- a/google-cloud-sdk/platform/gsutil/third_party/mock/docs/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/mock/docs/conf.py
@@ -62,8 +62,8 @@ html_theme_options = {}
 # The suffix of source filenames.
 source_suffix = '.txt'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General substitutions.
 project = u'Mock'

--- a/google-cloud-sdk/platform/gsutil/third_party/oauth2client/docs/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/oauth2client/docs/conf.py
@@ -48,7 +48,7 @@ extensions = [
 ]
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc = 'index'
+main_doc = 'index'
 
 # General information about the project.
 project = u'oauth2client'

--- a/google-cloud-sdk/platform/gsutil/third_party/pyasn1/doc/source/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/pyasn1/doc/source/conf.py
@@ -48,8 +48,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'contents'
+# The main toctree document.
+main_doc = 'contents'
 
 # General information about the project.
 project = u'PyASN1'
@@ -239,7 +239,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'PyASN1.tex', u'PyASN1 Documentation',
+    (main_doc, 'PyASN1.tex', u'PyASN1 Documentation',
      u'Ilya Etingof \\textless{}etingof@gmail.com\\textgreater{}', 'manual'),
 ]
 
@@ -269,7 +269,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'pyasn1', u'PyASN1 Documentation',
+    (main_doc, 'pyasn1', u'PyASN1 Documentation',
      [author], 1)
 ]
 
@@ -283,7 +283,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'PyASN1', u'PyASN1 Documentation',
+    (main_doc, 'PyASN1', u'PyASN1 Documentation',
      author, 'PyASN1', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/google-cloud-sdk/platform/gsutil/third_party/rsa/doc/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/rsa/doc/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Python-RSA'

--- a/google-cloud-sdk/platform/gsutil/third_party/six/documentation/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/six/documentation/conf.py
@@ -28,8 +28,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 #source_encoding = "utf-8-sig"
 
-# The master toctree document.
-master_doc = "index"
+# The main toctree document.
+main_doc = "index"
 
 # General information about the project.
 project = u"six"


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.